### PR TITLE
bump up elastica-bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,12 @@
             "Werkspot\\Pinba\\": ["tests/"]
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=5.3.0",
         "guzzlehttp/guzzle": "~6.0",
-        "friendsofsymfony/elastica-bundle": "*@dev"
+        "friendsofsymfony/elastica-bundle": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Elastica/TimedPaginatedFinder.php
+++ b/src/Elastica/TimedPaginatedFinder.php
@@ -2,6 +2,7 @@
 namespace Werkspot\Pinba\Elastica;
 
 use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
+use FOS\ElasticaBundle\Paginator\PaginatorAdapterInterface;
 use Werkspot\Pinba\PinbaTimer;
 
 /**
@@ -79,6 +80,25 @@ class TimedPaginatedFinder implements PaginatedFinderInterface
         $timer = $this->startTimer('createHybridPaginatorAdapter');
 
         $result = $this->finder->createHybridPaginatorAdapter($query);
+
+        $timer->stop();
+
+        return $result;
+    }
+
+    /**
+     * Creates a raw paginator adapter for this query.
+     *
+     * @param mixed $query
+     * @param array $options
+     *
+     * @return PaginatorAdapterInterface
+     */
+    public function createRawPaginatorAdapter($query, $options = [])
+    {
+        $timer = $this->startTimer('createRawPaginatorAdapter');
+
+        $result = $this->finder->createRawPaginatorAdapter($query, $options);
 
         $timer->stop();
 

--- a/tests/Elastica/TimedPaginatedFinderTest.php
+++ b/tests/Elastica/TimedPaginatedFinderTest.php
@@ -68,11 +68,37 @@ class TimedPaginatedFinderTest extends PHPUnit_Framework_TestCase
         // otherwise markTestAsSkipped would not test that
         $this->testCreatePaginatorAdapter();
 
-        $this->assertCorrectTagsSet([
-            'group' => 'elasticsearch',
-            'op' => 'createPaginatorAdapter',
-            'meta' => 'some_meta'
-        ]);
+        $this->assertCorrectTagsSet(
+            [
+                'group' => 'elasticsearch',
+                'op' => 'createPaginatorAdapter',
+                'meta' => 'some_meta'
+            ]
+        );
+    }
+
+    public function testCreateRawPaginatorAdapter()
+    {
+        $parentMock = Mockery::mock(PaginatedFinderInterface::class);
+        $parentMock->shouldReceive('createRawPaginatorAdapter')->with('foo', ['some_opt'])->andReturn('the result');
+
+        $finder = new TimedPaginatedFinder($parentMock, 'some_meta');
+        $this->assertSame('the result', $finder->createRawPaginatorAdapter('foo', ['some_opt']));
+    }
+
+    public function testCreateRawPaginatorAdapter_Tags()
+    {
+        // Separate test from so we can still test the implementation of find() even if we don't have pinba,
+        // otherwise markTestAsSkipped would not test that
+        $this->testCreatePaginatorAdapter();
+
+        $this->assertCorrectTagsSet(
+            [
+                'group' => 'elasticsearch',
+                'op' => 'createRawPaginatorAdapter',
+                'meta' => 'some_meta'
+            ]
+        );
     }
 
     private function assertCorrectTagsSet($tags)


### PR DESCRIPTION
We want to upgrade elasticsearch in the instapro project, which requires for an upgrade of `friendsofsymfony/elastica-bundle`, which in turn needs to be updated in our Pinba repo, which requires for a new method to be created in that project.